### PR TITLE
修复一些问题

### DIFF
--- a/src/main/java/org/WHITECN/anendrod.java
+++ b/src/main/java/org/WHITECN/anendrod.java
@@ -8,6 +8,7 @@ import org.WHITECN.commands.rodMerge;
 import org.WHITECN.items.HandcuffsAndKey;
 import org.WHITECN.listeners.DeathListener;
 import org.WHITECN.listeners.DroppedSplashPotion;
+import org.WHITECN.listeners.SlimesListener;
 import org.WHITECN.rods.*;
 import org.WHITECN.runnables.DeathRunnable;
 import org.WHITECN.runnables.HandcuffsRunnable;
@@ -51,6 +52,7 @@ public final class anendrod extends JavaPlugin {
         getServer().getPluginManager().registerEvents(new DeathListener(this),this);
         getServer().getPluginManager().registerEvents(new HandcuffsAndKey(),this);
         getServer().getPluginManager().registerEvents(new DroppedSplashPotion(),this);
+        getServer().getPluginManager().registerEvents(new SlimesListener(),this);
         Bukkit.getPluginManager().registerEvents(new Listener() {
             @EventHandler
             public void onPluginEnable(PluginEnableEvent event) {

--- a/src/main/java/org/WHITECN/commands/rodMerge.java
+++ b/src/main/java/org/WHITECN/commands/rodMerge.java
@@ -81,7 +81,7 @@ public class rodMerge implements CommandExecutor, Listener ,TabCompleter{
                         }
                         tagUtils.ensureTag(target,"rodUsed","0");
                         tagUtils.setTag(target,"rodUsed",String.valueOf(usedCount));
-                    }catch (ClassCastException e){
+                    }catch (NumberFormatException e){
                         player.sendMessage(prefix + "§c请按照提示要求输入喵!");
                         return true;
                     }
@@ -89,7 +89,7 @@ public class rodMerge implements CommandExecutor, Listener ,TabCompleter{
 
                 case "getrodused":
                     if (!sender.isOp()) {
-                        sender.sendMessage(prefix + "§c你没有权限使用 setrodused 喵~");
+                        sender.sendMessage(prefix + "§c你没有权限使用 getrodused 喵~");
                         return true;
                     }
                     if (args.length != 2){

--- a/src/main/java/org/WHITECN/items/HandcuffsAndKey.java
+++ b/src/main/java/org/WHITECN/items/HandcuffsAndKey.java
@@ -107,11 +107,12 @@ public class HandcuffsAndKey implements Listener{
 
         Player user  = event.getPlayer();
         Player target = (Player) event.getRightClicked();
-        tagUtils.ensureTag(target,"canCuff","false");
         ItemStack mainHand = user.getInventory().getItemInMainHand();
-        ItemMeta meta = mainHand.getItemMeta();
         if (!mainHand.hasItemMeta()) return;
-        if (!handCuffsName.equals(meta.getDisplayName())) return;
+        ItemMeta meta = mainHand.getItemMeta();
+        if (meta == null || mainHand.getType() != Material.CHAINMAIL_CHESTPLATE || !handCuffsName.equals(meta.getDisplayName())) return;
+
+        tagUtils.ensureTag(target,"canCuff","false");
         if (tagUtils.getTag(target,"canCuff").equals("false")){
             user.sendMessage(prefix + "§c该玩家已禁用手铐玩法！");
             return;

--- a/src/main/java/org/WHITECN/listeners/SlimesListener.java
+++ b/src/main/java/org/WHITECN/listeners/SlimesListener.java
@@ -11,7 +11,8 @@ public class SlimesListener implements Listener {
     public void onDeath(EntityDeathEvent event){
         if (event.getEntityType() != EntityType.SLIME) return;
         LivingEntity entity = event.getEntity();
-        if (entity.getCustomName().contains("附着物")){
+        String customName = entity.getCustomName();
+        if (customName != null && customName.contains("附着物")){
             event.setDroppedExp(0);
             event.getDrops().clear();
         }

--- a/src/main/java/org/WHITECN/rods/AbstractRod.java
+++ b/src/main/java/org/WHITECN/rods/AbstractRod.java
@@ -5,6 +5,7 @@ import net.md_5.bungee.api.chat.TextComponent;
 import org.WHITECN.Vars;
 import org.WHITECN.anendrod;
 import org.WHITECN.utils.AdvancementHandler;
+import org.WHITECN.utils.DeathStatus;
 import org.WHITECN.utils.SQLiteUtils;
 import org.WHITECN.utils.tagUtils;
 import org.WHITECN.utils.useCounter;
@@ -155,6 +156,7 @@ public abstract class AbstractRod implements Listener {
 
         //正片开始(bushi
         target.playSound(player, Insert_sounds.get(random.nextInt(Insert_sounds.size())), 1.0f, 1.0f);
+        DeathStatus.add(player.getUniqueId(), target.getUniqueId(), getDeathStatusDuration(), item);
         onUse(player, target);
         target.setNoDamageTicks(5);
         player.setCooldown(Material.END_ROD, this.cooldown);
@@ -174,7 +176,10 @@ public abstract class AbstractRod implements Listener {
             SQLiteUtils.setCTCount(playerName, SQLiteUtils.getCTCount(playerName) + 1);
             SQLiteUtils.setChaCount(targetName, SQLiteUtils.getChaCount(targetName) + 1);
         });
-        AdvancementHandler.advancementTest(target); //成就
+    }
+
+    protected double getDeathStatusDuration() {
+        return 10;
     }
     
     //如果需要更新其他的数据要重写这个

--- a/src/main/java/org/WHITECN/rods/RegularProRod.java
+++ b/src/main/java/org/WHITECN/rods/RegularProRod.java
@@ -36,7 +36,7 @@ public class RegularProRod extends AbstractRod{
     }
 
     @Override
-    public void onUse(Player player, Player target) {
+    public void onUse(Player user, Player player) {
         Plugin plug = JavaPlugin.getPlugin(anendrod.class);
         player.addPotionEffect(new PotionEffect(PotionEffectType.WEAKNESS, 50 * 20, 3));
         player.addPotionEffect(new PotionEffect(PotionEffectType.SLOW, 80 * 20, 3));
@@ -144,6 +144,11 @@ public class RegularProRod extends AbstractRod{
                 t++;
             }
         }.runTaskTimer(plug, 0L, 1L);
+    }
+
+    @Override
+    protected double getDeathStatusDuration() {
+        return (80 + 10) * 20;
     }
 
     @Override

--- a/src/main/java/org/WHITECN/rods/SlimeRod.java
+++ b/src/main/java/org/WHITECN/rods/SlimeRod.java
@@ -44,6 +44,11 @@ public class SlimeRod extends AbstractRod {
     }
 
     @Override
+    protected double getDeathStatusDuration() {
+        return 10 * 20;
+    }
+
+    @Override
     public ItemStack createItemStack() {
         ItemStack rod = createBaseItemStack();
         ItemMeta meta = rod.getItemMeta();

--- a/src/main/java/org/WHITECN/runnables/HandcuffsRunnable.java
+++ b/src/main/java/org/WHITECN/runnables/HandcuffsRunnable.java
@@ -3,22 +3,24 @@ package org.WHITECN.runnables;
 import org.WHITECN.items.HandcuffsAndKey;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
 import org.bukkit.scheduler.BukkitRunnable;
-
-import java.util.Objects;
 
 public class HandcuffsRunnable extends BukkitRunnable{
     @Override
     public void run() {
         for (Player p : Bukkit.getOnlinePlayers()) {
-            if (Objects.requireNonNull(Objects.requireNonNull(p.getEquipment()).getChestplate()).getItemMeta() != null) {
-                if (p.getEquipment().getChestplate().getItemMeta().getDisplayName().equals(HandcuffsAndKey.handCuffsName)) {
-                    p.addPotionEffect(new PotionEffect(PotionEffectType.WEAKNESS,20, 9, false, false));
-                    p.addPotionEffect(new PotionEffect(PotionEffectType.SLOW_DIGGING, 20, 9, false, false));
-                }
-            }
+            ItemStack chestplate = p.getInventory().getChestplate();
+            if (chestplate == null || !chestplate.hasItemMeta()) continue;
+
+            ItemMeta meta = chestplate.getItemMeta();
+            if (meta == null || !HandcuffsAndKey.handCuffsName.equals(meta.getDisplayName())) continue;
+
+            p.addPotionEffect(new PotionEffect(PotionEffectType.WEAKNESS,20, 9, false, false));
+            p.addPotionEffect(new PotionEffect(PotionEffectType.SLOW_DIGGING, 20, 9, false, false));
         }
     }
 }


### PR DESCRIPTION
玩家没穿胸甲时NPE
普通无名称史莱姆死亡时NPE
`SlimesListener` 存在但没有注册
自定义死亡消息失效
普通末地烛Pro 对其他玩家使用时效果施加到自己
重复调用两次成就检查
重命名成“手铐”的物品都被当作手铐
`rodmerge` 捕获 `ClassCastException` 但非法数字实际抛出 `NumberFormatException`